### PR TITLE
Jump to version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <groupId>pt.ua.dicoogle.demo</groupId>
     <artifactId>dicoogle-plugin-sample</artifactId>
     <name>dicoogle-plugin-sample</name>
-    <version>2.4.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dicoogle SDK version here -->
-        <dicoogle.version>2.4.0</dicoogle.version>
+        <dicoogle.version>3.0.0</dicoogle.version>
 
         <!-- Jetty server version here -->        
         <jetty.version>9.0.3.v20130506</jetty.version>
@@ -93,18 +93,18 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.org</url>
         </repository>
         <repository>
             <id>mavencentral</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
         <repository>
             <id>dcm4che</id>
-            <url>http://www.dcm4che.org/maven2/</url>
+            <url>https://www.dcm4che.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -112,7 +112,7 @@
 
         <repository>
             <id>mi</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -120,7 +120,7 @@
 
         <repository>
             <id>mi-snapshots</id>
-            <url>http://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/src/main/java/pt/ieeta/dicoogle/plugin/demo/dicooglepluginsample/RSIPluginSet.java
+++ b/src/main/java/pt/ieeta/dicoogle/plugin/demo/dicooglepluginsample/RSIPluginSet.java
@@ -26,7 +26,6 @@ import net.xeoh.plugins.base.annotations.PluginImplementation;
 import org.restlet.resource.ServerResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pt.ua.dicoogle.sdk.GraphicalInterface;
 import pt.ua.dicoogle.sdk.IndexerInterface;
 import pt.ua.dicoogle.sdk.JettyPluginInterface;
 import pt.ua.dicoogle.sdk.PluginSet;
@@ -126,9 +125,4 @@ public class RSIPluginSet implements PluginSet {
         return this.settings;
     }
 
-    @Override
-    public Collection<GraphicalInterface> getGraphicalPlugins() {
-        // Graphical plugins are deprecated. Do not use or provide any.
-        return Collections.EMPTY_LIST;
-    }
 }


### PR DESCRIPTION
This is only a simple port of the sample plugins to version 3.0.0.
We need to make sure that there is no broken dependencies, such as, OpenAPI or other broken docs.