### PR TITLE
Fix building sample plugin with the latest repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dicoogle SDK version here -->
-        <dicoogle.version>3.2.0</dicoogle.version>
+        <dicoogle.version>3.2.2</dicoogle.version>
 
         <!-- Jetty server version here -->        
         <jetty.version>9.0.3.v20130506</jetty.version>
@@ -40,9 +40,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <!-- For access to Java 8 capabilities, replace source
-                         and target versions to 1.8
-                    -->
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
@@ -91,36 +88,30 @@
     </build>
     <repositories>
         <repository>
-            <id>maven-restlet</id>
-            <name>Public online Restlet repository</name>
-            <url>https://maven.restlet.org</url>
-        </repository>
-        <repository>
             <id>mavencentral</id>
             <url>https://repo1.maven.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>dcm4che</id>
-            <url>https://www.dcm4che.org/maven2/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
 
         <repository>
-            <id>mi</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi</url>
+            <id>dicoogle-public</id>
+            <url>https://dev.bmd-software.com/nexus/content/repositories/dicoogle-public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
         </repository>
 
         <repository>
-            <id>mi-snapshots</id>
-            <url>https://bioinformatics.ua.pt/maven/content/repositories/mi-snapshots</url>
+            <id>maven-restlet</id>
+            <name>Public online Restlet repository</name>
+            <url>https://maven.restlet.talend.com</url>
+        </repository>
+
+        <repository>
+            <id>dcm4che</id>
+            <url>https://www.dcm4che.org/maven2/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
- replace bioinformatics maven repo with dicoogle-public
- update dicoogle-sdk to 3.2.2
- update restlet maven repo
- remove outdated comment